### PR TITLE
Ocp violation

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationFormatter.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationFormatter.java
@@ -1,0 +1,7 @@
+package com.squareup.javapoet;
+
+import java.io.IOException;
+
+public interface AnnotationFormatter {
+    void format(AnnotationSpec annotationSpec, CodeWriter codeWriter, boolean inline) throws IOException;
+}

--- a/src/main/java/com/squareup/javapoet/AnnotationFormatter.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationFormatter.java
@@ -3,5 +3,7 @@ package com.squareup.javapoet;
 import java.io.IOException;
 
 public interface AnnotationFormatter {
-    void format(AnnotationSpec annotationSpec, CodeWriter codeWriter, boolean inline) throws IOException;
+    void format(AnnotationSpec annotationSpec,
+                CodeWriter codeWriter,
+                boolean inline) throws IOException;
 }

--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,9 @@ public final class AnnotationSpec {
   private AnnotationSpec(Builder builder) {
     this.type = builder.type;
     this.members = Util.immutableMultimap(builder.members);
-    this.formatter = builder.formatter != null ? builder.formatter : new DefaultAnnotationFormatter();
+    this.formatter = builder.formatter != null
+            ? builder.formatter
+            : new DefaultAnnotationFormatter();
   }
 
   void emit(CodeWriter codeWriter, boolean inline) throws IOException {

--- a/src/main/java/com/squareup/javapoet/DefaultAnnotationFormatter.java
+++ b/src/main/java/com/squareup/javapoet/DefaultAnnotationFormatter.java
@@ -1,0 +1,52 @@
+package com.squareup.javapoet;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultAnnotationFormatter implements AnnotationFormatter {
+    @Override
+    public void format(AnnotationSpec annotationSpec, CodeWriter codeWriter, boolean inline) throws IOException {
+        String whitespace = inline ? "" : "\n";
+        String memberSeparator = inline ? ", " : ",\n";
+
+        if (annotationSpec.members.isEmpty()) {
+            codeWriter.emit("@$T", annotationSpec.type);  // No members
+        } else if (annotationSpec.members.size() == 1 && annotationSpec.members.containsKey(AnnotationSpec.VALUE)) {
+            codeWriter.emit("@$T(", annotationSpec.type);  // Single "value" member
+            emitAnnotationValues(codeWriter, whitespace, memberSeparator, annotationSpec.members.get(AnnotationSpec.VALUE));
+            codeWriter.emit(")");
+        } else {
+            codeWriter.emit("@$T(" + whitespace, annotationSpec.type);  // Multiple members
+            codeWriter.indent(2);
+            for (Iterator<Map.Entry<String, List<CodeBlock>>> i = annotationSpec.members.entrySet().iterator(); i.hasNext(); ) {
+                Map.Entry<String, List<CodeBlock>> entry = i.next();
+                codeWriter.emit("$L = ", entry.getKey());
+                emitAnnotationValues(codeWriter, whitespace, memberSeparator, entry.getValue());
+                if (i.hasNext()) codeWriter.emit(memberSeparator);
+            }
+            codeWriter.unindent(2);
+            codeWriter.emit(whitespace + ")");
+        }
+    }
+
+    private void emitAnnotationValues(CodeWriter codeWriter, String whitespace, String memberSeparator, List<CodeBlock> values) throws IOException {
+        if (values.size() == 1) {
+            codeWriter.indent(2);
+            codeWriter.emit(values.get(0));  // Single value
+            codeWriter.unindent(2);
+        } else {
+            codeWriter.emit("{" + whitespace);  // Multiple values
+            codeWriter.indent(2);
+            boolean first = true;
+            for (CodeBlock codeBlock : values) {
+                if (!first) codeWriter.emit(memberSeparator);
+                codeWriter.emit(codeBlock);
+                first = false;
+            }
+            codeWriter.unindent(2);
+            codeWriter.emit(whitespace + "}");
+        }
+    }
+}

--- a/src/main/java/com/squareup/javapoet/DefaultAnnotationFormatter.java
+++ b/src/main/java/com/squareup/javapoet/DefaultAnnotationFormatter.java
@@ -7,31 +7,38 @@ import java.util.Map;
 
 public class DefaultAnnotationFormatter implements AnnotationFormatter {
     @Override
-    public void format(AnnotationSpec annotationSpec, CodeWriter codeWriter, boolean inline) throws IOException {
+    public void format(AnnotationSpec annotationSpec, CodeWriter codeWriter, boolean inline)
+            throws IOException {
         String whitespace = inline ? "" : "\n";
         String memberSeparator = inline ? ", " : ",\n";
 
         if (annotationSpec.members.isEmpty()) {
             codeWriter.emit("@$T", annotationSpec.type);  // No members
-        } else if (annotationSpec.members.size() == 1 && annotationSpec.members.containsKey(AnnotationSpec.VALUE)) {
+        } else if (annotationSpec.members.size() == 1
+                && annotationSpec.members.containsKey(AnnotationSpec.VALUE)) {
             codeWriter.emit("@$T(", annotationSpec.type);  // Single "value" member
-            emitAnnotationValues(codeWriter, whitespace, memberSeparator, annotationSpec.members.get(AnnotationSpec.VALUE));
+            emitAnnotationValues(codeWriter, whitespace, memberSeparator,
+                    annotationSpec.members.get(AnnotationSpec.VALUE));
             codeWriter.emit(")");
         } else {
             codeWriter.emit("@$T(" + whitespace, annotationSpec.type);  // Multiple members
             codeWriter.indent(2);
-            for (Iterator<Map.Entry<String, List<CodeBlock>>> i = annotationSpec.members.entrySet().iterator(); i.hasNext(); ) {
+            for (Iterator<Map.Entry<String, List<CodeBlock>>> i
+                 = annotationSpec.members.entrySet().iterator(); i.hasNext(); ) {
                 Map.Entry<String, List<CodeBlock>> entry = i.next();
                 codeWriter.emit("$L = ", entry.getKey());
                 emitAnnotationValues(codeWriter, whitespace, memberSeparator, entry.getValue());
-                if (i.hasNext()) codeWriter.emit(memberSeparator);
+                if (i.hasNext()) {
+                    codeWriter.emit(memberSeparator);
+                }
             }
             codeWriter.unindent(2);
             codeWriter.emit(whitespace + ")");
         }
     }
 
-    private void emitAnnotationValues(CodeWriter codeWriter, String whitespace, String memberSeparator, List<CodeBlock> values) throws IOException {
+    private void emitAnnotationValues(CodeWriter codeWriter, String whitespace,
+                                String memberSeparator, List<CodeBlock> values) throws IOException {
         if (values.size() == 1) {
             codeWriter.indent(2);
             codeWriter.emit(values.get(0));  // Single value
@@ -41,7 +48,9 @@ public class DefaultAnnotationFormatter implements AnnotationFormatter {
             codeWriter.indent(2);
             boolean first = true;
             for (CodeBlock codeBlock : values) {
-                if (!first) codeWriter.emit(memberSeparator);
+                if (!first) {
+                    codeWriter.emit(memberSeparator);
+                }
                 codeWriter.emit(codeBlock);
                 first = false;
             }

--- a/src/test/java/OwnTest.java
+++ b/src/test/java/OwnTest.java
@@ -4,8 +4,16 @@ import java.io.IOException;
 
 public class OwnTest {
     public static void main(String[] args) throws IOException {
+        AnnotationSpec methodAnnotation = AnnotationSpec.builder(Override.class).build();
+
+        AnnotationSpec classAnnotation = AnnotationSpec.builder(Deprecated.class)
+                .addMember("since", "$S", "1.0")
+                .addMember("forRemoval", "$L", true)
+                .build();
+
         MethodSpec main = MethodSpec.methodBuilder("main")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addAnnotation(methodAnnotation) // Add annotation to the method
                 .returns(void.class)
                 .addParameter(String[].class, "args")
                 .addStatement("$T.out.println($S)", System.class, "Hello World")
@@ -13,12 +21,12 @@ public class OwnTest {
 
         TypeSpec helloWorld = TypeSpec.classBuilder("HelloWorld")
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addAnnotation(classAnnotation) // Add annotation to the class
                 .addMethod(main)
                 .build();
 
         JavaFile javaFile = JavaFile.builder("com.example.helloworld", helloWorld)
                 .build();
-
         javaFile.writeTo(System.out);
     }
 }

--- a/src/test/java/com/squareup/javapoet/AnnotationIntegrationTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationIntegrationTest.java
@@ -1,0 +1,23 @@
+package com.squareup.javapoet;
+import javax.lang.model.element.Modifier;
+import java.io.IOException;
+
+public class AnnotationIntegrationTest {
+
+    //Test the integration of AnnotationSpec with TypeSpec and JavaFile
+    public static void main(String[] args) throws IOException {
+        AnnotationSpec testAnnotation = AnnotationSpec.builder(SuppressWarnings.class)
+                .addMember("value", "$S", "unchecked")
+                .build();
+
+        TypeSpec testClass = TypeSpec.classBuilder("TestClass")
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(testAnnotation)
+                .build();
+
+        JavaFile javaFile = JavaFile.builder("com.example", testClass)
+                .build();
+
+        javaFile.writeTo(System.out);
+    }
+}


### PR DESCRIPTION
extracted formatting from AnnotationSpec. reduces coupling and adheres to OCP because new annotation formatting rules can be added by adding a new AnnotationFormatter without needing to make changes in the AnnotationSpec.  Furthermore resolves the SRP violation because AnnotationSpec was also handling formatting tasks.